### PR TITLE
Expose InitializationOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,4 +30,8 @@
 
 # 0.1.8 - January 2024
 
-- Make `BrazeClient.identify() non-static`
+- Make `BrazeClient.identify()` non-static
+
+# 0.1.9 - January 2024
+
+- Expose `InitializationOptions`

--- a/lib/braze_plugin_web.dart
+++ b/lib/braze_plugin_web.dart
@@ -1,3 +1,4 @@
 library braze_plugin_web;
 
 export 'src/braze_plugin_web.dart' show BrazeClient;
+export 'src/braze_plugin_js.dart' show InitializationOptions;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: braze_plugin_web
 description: Unofficial Braze Plugin for Flutter for Web. It is mostly a Flutter Web Plugin acting as a wrapper around the official Braze Web SDK.
 repository: https://github.com/jasper-health/braze_plugin_web_fork
-version: 0.1.8
+version: 0.1.9
 
 environment:
   sdk: ">=2.17.6 <4.0.0"


### PR DESCRIPTION
InitializationOptions is needed for additional configurations when setting up Braze in web apps