### PR TITLE
Fix BrazePluginJS.requestContentCardsRefresh signature; bump version to 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,7 @@
 # 0.1.11 - March 2024
 
 - Add `User.getUserId()` and `getUserId()`
+
+# 0.1.12 - March 2024
+
+- Fix `BrazePluginJS.requestContentCardsRefresh()` signature

--- a/lib/src/braze_plugin_js.dart
+++ b/lib/src/braze_plugin_js.dart
@@ -29,7 +29,7 @@ class BrazePluginJS {
     Function(ListBrazeCardsJsImpl cards) d,
   );
 
-  external static requestContentCardsRefresh<T>(
+  external static requestContentCardsRefresh(
     Function() successCallback,
     Function() errorCallback,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: braze_plugin_web
 description: Unofficial Braze Plugin for Flutter for Web. It is mostly a Flutter Web Plugin acting as a wrapper around the official Braze Web SDK.
 repository: https://github.com/jasper-health/braze_plugin_web_fork
-version: 0.1.11
+version: 0.1.12
 
 environment:
   sdk: ">=2.17.6 <4.0.0"


### PR DESCRIPTION
I noticed that neither the `onSuccess` nor `onError` callbacks were being called when we make this call in the flutter web app:  `_braze.requestContentCardsRefresh(onSuccess: F, onError: F)` 

Once I removed this `<T>` from the function signature, it started working.  So this _might_ fix the content cards display issue.    
